### PR TITLE
feat: Add preliminary conda recipe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v4.4.0
   hooks:
   - id: check-yaml
+    exclude: "conda.recipe/meta.yaml"
   - id: check-toml
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -12,6 +13,7 @@ repos:
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --preserve-quotes, --indent, '2']
+    exclude: "conda.recipe/meta.yaml"
   - id: pretty-format-toml
     args: [--autofix]
 - repo: https://github.com/asottile/pyupgrade

--- a/conda.recipe/LICENSE
+++ b/conda.recipe/LICENSE
@@ -1,0 +1,27 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,41 @@
+{% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
+{% set project = pyproject['project'] %}
+
+{% set name = project['name'] %}
+{% set version = VERSION %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  script:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{version}} {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - python {{ project['requires-python'] }}
+    - pip
+    {% for dep in pyproject['build-system']['requires'] %}
+    - {{ dep.lower() }}
+    {% endfor %}
+  run:
+    - python {{ project['requires-python'] }}
+    {% for dep in project['dependencies'] %}
+    - {{ dep.lower() }}
+    {% endfor %}
+
+test:
+  imports:
+    - conda_tui
+  commands:
+    - conda tui --help
+about:
+#  home: {{ project['urls']['repository'] }}
+  summary: {{ project['description'] }}
+  license: {{ project['license']['text'] }}
+  license_file: LICENSE

--- a/src/conda_tui/app.py
+++ b/src/conda_tui/app.py
@@ -46,7 +46,10 @@ class CondaTUI(App):
 
 def run(argv: Optional[list[str]] = None) -> None:
     """Run the application."""
-    argv = argv or sys.argv[1:]
+    argv = argv or sys.argv
+    while argv[0] in {"conda", "tui", "conda-tui"}:
+        argv = argv[1:]
+
     parser = argparse.ArgumentParser("conda tui")
     parser.add_argument("--no-dark", action="store_true", help="Disable dark mode")
     args = parser.parse_args(argv)


### PR DESCRIPTION
* Adds a preliminary conda recipe to publish to `mattkram::conda-tui`
* Fixes handling of arguments to allow both `conda tui` and `conda-tui`
* Minor cleanup by ignoring `.mypy_cache` directory